### PR TITLE
Exporting (@exporting) Darwin import

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -16,7 +16,7 @@
  */
 
 /* Required for setlocale(3) */
-import Darwin
+@exported import Darwin
 
 let ShortOptionPrefix = "-"
 let LongOptionPrefix = "--"


### PR DESCRIPTION
Exporting the Darwin import so that the user of this library does not have to explicitly import Darwin to get access to exit(), etc.
