### PR TITLE
Update to Swift 1.2

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -155,7 +155,7 @@ public class CommandLine {
       /* Swift strings don't have substringFromIndex(). Do a little dance instead. */
       var flag = ""
       var skipChars =
-        arg.hasPrefix(LongOptionPrefix) ? countElements(LongOptionPrefix) : countElements(ShortOptionPrefix)
+        arg.hasPrefix(LongOptionPrefix) ? count(LongOptionPrefix) : count(ShortOptionPrefix)
       for c in arg {
         if skipChars-- > 0 {
           continue
@@ -183,7 +183,7 @@ public class CommandLine {
       /* Flags that do not take any arguments can be concatenated */
       if !flagMatched && !arg.hasPrefix(LongOptionPrefix) {
         for (i, c) in enumerate(flag) {
-          var flagLength = countElements(flag)
+          var flagLength = count(flag)
           for option in _options {
             if String(c) == option.shortFlag {
               /* Values are allowed at the end of the concatenated flags, e.g.
@@ -218,7 +218,7 @@ public class CommandLine {
     var flagWidth = 0
     for opt in _options {
       flagWidth = max(flagWidth,
-        countElements("  \(ShortOptionPrefix)\(opt.shortFlag), \(LongOptionPrefix)\(opt.longFlag):"))
+        count("  \(ShortOptionPrefix)\(opt.shortFlag), \(LongOptionPrefix)\(opt.longFlag):"))
     }
     
     println("Usage: \(name) [options]")

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -161,7 +161,9 @@ public class CommandLine {
           continue
         }
         
-        flag.append(c)
+        // Swift 1.2: String.append() doesn't like emoji for some reason, seems
+        // like a bug. Same workaround in String extension splitByCharacter()
+        flag = flag + String(c)
       }
       
       /* Remove attached argument from flag */

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -36,7 +36,7 @@ public class Option {
   }
   
   public init(shortFlag: String, longFlag: String, required: Bool, helpMessage: String) {
-    assert(countElements(shortFlag) == 1, "Short flag must be a single character")
+    assert(count(shortFlag) == 1, "Short flag must be a single character")
     assert(shortFlag.toInt() == nil && shortFlag.toDouble() == nil, "Short flag cannot be a numeric value")
     assert(longFlag.toInt() == nil && longFlag.toDouble() == nil, "Long flag cannot be a numeric value")
     

--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -70,7 +70,7 @@ internal extension String {
     }
     
     return (Double(characteristic.toInt()!) +
-      Double(mantissa.toInt()!) / pow(Double(10), Double(countElements(mantissa) - 1))) *
+      Double(mantissa.toInt()!) / pow(Double(10), Double(count(mantissa) - 1))) *
       (isNegative ? -1 : 1)
   }
   
@@ -98,7 +98,7 @@ internal extension String {
       buf.append(c)
     }
     
-    if countElements(buf) > 0 {
+    if count(buf) > 0 {
       s.append(buf)
     }
     
@@ -115,7 +115,7 @@ internal extension String {
    */
   func paddedToWidth(width: Int, padBy: Character = " ") -> String {
     var s = self
-    var currentLength = countElements(self)
+    var currentLength = count(self)
     
     while currentLength++ < width {
       s.append(padBy)
@@ -142,7 +142,7 @@ internal extension String {
     var currentLineWidth = 0
     
     for word in self.splitByCharacter(splitBy) {
-      let wordLength = countElements(word)
+      let wordLength = count(word)
       
       if currentLineWidth + wordLength + 1 > width {
         /* Word length is greater than line length, can't wrap */

--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -95,7 +95,7 @@ internal extension String {
         continue
       }
       
-      buf.append(c)
+      buf = buf + String(c)
     }
     
     if count(buf) > 0 {

--- a/CommandLineTests/StringExtensionTests.swift
+++ b/CommandLineTests/StringExtensionTests.swift
@@ -102,9 +102,9 @@ class StringExtensionTests: XCTestCase {
   func testPaddedByCharacter() {
     let a = "this is a test"
     
-    XCTAssertEqual(countElements(a.paddedToWidth(80)), 80, "Failed to pad to correct width")
-    XCTAssertEqual(countElements(a.paddedToWidth(5)), countElements(a), "Bad padding when pad width is less than string width")
-    XCTAssertEqual(countElements(a.paddedToWidth(-2)), countElements(a), "Bad padding with negative pad width")
+    XCTAssertEqual(count(a.paddedToWidth(80)), 80, "Failed to pad to correct width")
+    XCTAssertEqual(count(a.paddedToWidth(5)), count(a), "Bad padding when pad width is less than string width")
+    XCTAssertEqual(count(a.paddedToWidth(-2)), count(a), "Bad padding with negative pad width")
     
     let b = a.paddedToWidth(80)
     let lastBCharIndex = advance(b.endIndex, -1)
@@ -118,7 +118,7 @@ class StringExtensionTests: XCTestCase {
   func testWrappedAtWidth() {
     let lipsum = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
     for line in lipsum.wrappedAtWidth(80).splitByCharacter("\n") {
-      XCTAssertLessThanOrEqual(countElements(line), 80, "Failed to wrap long line: \(line)")
+      XCTAssertLessThanOrEqual(count(line), 80, "Failed to wrap long line: \(line)")
     }
     
     /* Words longer than the wrap width should not be split */
@@ -126,7 +126,7 @@ class StringExtensionTests: XCTestCase {
     let lines = longWords.wrappedAtWidth(3).splitByCharacter("\n")
     XCTAssertEqual(lines.count, 8, "Failed to wrap long words")
     for line in lines {
-      XCTAssertGreaterThan(countElements(line), 3, "Bad long word wrapping on line: \(line)")
+      XCTAssertGreaterThan(count(line), 3, "Bad long word wrapping on line: \(line)")
     }
   }
 }


### PR DESCRIPTION
Hi @jatoben! Updated to Swift 1.2, all tests pass. Here are the changes:

- `countElements()` was renamed to `count()`
- `String.append()` doesn't like emoji for some reason now, seems like a bug. So I added a small workaround for that as `testEmojiOptions` was failing