### PR TITLE
String.append() fixed in Xcode 6.3 Beta 3

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -161,9 +161,7 @@ public class CommandLine {
           continue
         }
         
-        // Swift 1.2: String.append() doesn't like emoji for some reason, seems
-        // like a bug. Same workaround in String extension splitByCharacter()
-        flag = flag + String(c)
+        flag.append(c)
       }
       
       /* Remove attached argument from flag */

--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -95,7 +95,7 @@ internal extension String {
         continue
       }
       
-      buf = buf + String(c)
+      buf.append(c)
     }
     
     if count(buf) > 0 {


### PR DESCRIPTION
String.append() was broken in some cases (see https://github.com/jatoben/CommandLine/pull/12), but it's fixed now — switching back.