### PR TITLE
Add strict mode

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -141,7 +141,7 @@ public class CommandLine {
    * :returns: True if all arguments were parsed successfully, false if any option had an
    *   invalid value or if a required option was missing.
    */
-  public func parse() -> (Bool, String?) {
+  public func parse(strict: Bool = false) -> (Bool, String?) {
     
     for (idx, arg) in enumerate(_arguments) {
       if arg == ArgumentStopper {
@@ -199,10 +199,16 @@ public class CommandLine {
                 return (false, "Invalid value for \(option.longFlag)")
               }
               
+              flagMatched = true
               break
             }
           }
         }
+      }
+
+      /* Invalid flag */
+      if strict && !flagMatched {
+        return (false, "Invalid argument: \(arg)")
       }
     }
 

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -436,4 +436,19 @@ internal class CommandLineTests: XCTestCase {
     XCTAssertEqual(doubleOpt.value!, 0.05, "Failed to get correct double value from mixed command line")
     XCTAssertEqual(extraOpt.value!.count  , 3, "Failed to get correct number of multistring options from mixed command line")
   }
+
+  func testStrictMode() {
+    let cli = CommandLine(arguments: [ "CommandLineTests", "--valid", "--invalid"])
+    let validOpt = BoolOption(shortFlag: "v", longFlag: "valid", helpMessage: "Known flag.")
+    cli.addOptions(validOpt)
+
+    var (success, error) = cli.parse(strict: false)
+    XCTAssertTrue(success, "Failed to parsed invalid flags in non-strict mode")
+    XCTAssertNil(error, "non-nil parse error after successful parse")
+
+    var (successStrict, errorStrict) = cli.parse(strict: true)
+    XCTAssertFalse(successStrict, "Successfully parsed invalid flags in strict mode")
+    XCTAssertNotNil(errorStrict, "nil parse error after failed parse")
+  }
+
 }


### PR DESCRIPTION
Strict mode lets parsing fail if the command line contains unknown arguments