### PR TITLE
Add Xcode 6.3 to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: objective-c
 xcode_project: CommandLine.xcodeproj
 xcode_scheme: CommandLine
 script: xcodebuild -scheme CommandLine test
+osx_image: beta-xcode6.3

--- a/CommandLine/Info.plist
+++ b/CommandLine/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.github.jatoben.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>com.github.jatoben.$(PRODUCT_NAME:rfc1034identifier)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Travis CI has [added Xcode 6.3 builds](http://blog.travis-ci.com/2015-05-26-xcode-63-beta-general-availability/).