### PR TITLE
Allow Options with only short or long flags

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -264,14 +264,12 @@ public class CommandLine {
     
     var flagWidth = 0
     for opt in _options {
-      flagWidth = max(flagWidth,
-        "  \(ShortOptionPrefix)\(opt.shortFlag), \(LongOptionPrefix)\(opt.longFlag):".characters.count)
+      flagWidth = max(flagWidth, "  \(opt.flagDescription):".characters.count)
     }
 
     print("Usage: \(name) [options]", &to)
     for opt in _options {
-      let flags = "  \(ShortOptionPrefix)\(opt.shortFlag), \(LongOptionPrefix)\(opt.longFlag):".paddedToWidth(flagWidth)
-      
+      let flags = "  \(opt.flagDescription):".paddedToWidth(flagWidth)
       print("\(flags)\n      \(opt.helpMessage)", &to)
     }
   }

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -199,9 +199,9 @@ public class CommandLine {
       
       var flagMatched = false
       for option in _options {
-        if flag == option.shortFlag || flag == option.longFlag {
+        if option.flagMatch(flag) {
           let vals = self._getFlagValues(idx)
-          guard option.match(vals) else {
+          guard option.setValue(vals) else {
             throw ParseError.InvalidValueForOption(option, vals)
           }
           
@@ -211,16 +211,16 @@ public class CommandLine {
       }
       
       /* Flags that do not take any arguments can be concatenated */
+      let flagLength = flag.characters.count
       if !flagMatched && !arg.hasPrefix(LongOptionPrefix) {
         for (i, c) in flag.characters.enumerate() {
-          let flagLength = flag.characters.count
           for option in _options {
-            if String(c) == option.shortFlag {
+            if option.flagMatch(String(c)) {
               /* Values are allowed at the end of the concatenated flags, e.g.
                * -xvf <file1> <file2>
                */
               let vals = (i == flagLength - 1) ? self._getFlagValues(idx) : [String]()
-              guard option.match(vals) else {
+              guard option.setValue(vals) else {
                 throw ParseError.InvalidValueForOption(option, vals)
               }
               

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -31,7 +31,7 @@ public class Option {
     case (_, let lf) where lf != nil:
       return "\(LongOptionPrefix)\(lf!)"
     default:
-      return "\(ShortOptionPrefix)\(shortFlag)"
+      return "\(ShortOptionPrefix)\(shortFlag!)"
     }
   }
   

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -23,6 +23,8 @@ public class Option {
   var longFlag: String
   var required: Bool
   var helpMessage: String
+  let shortFlag: String?
+  let longFlag: String?
   
   /* Override this property to test _value for nil on each Option subclass.
    *
@@ -46,7 +48,11 @@ public class Option {
     self.required = required
   }
   
-  func match(values: [String]) -> Bool {
+  func flagMatch(flag: String) -> Bool {
+    return flag == shortFlag || flag == longFlag
+  }
+  
+  func setValue(values: [String]) -> Bool {
     return false
   }
 }
@@ -71,7 +77,7 @@ public class BoolOption: Option {
     super.init(shortFlag: shortFlag, longFlag: longFlag, required: false, helpMessage: helpMessage)
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     _value = true
     return true
   }
@@ -89,7 +95,7 @@ public class IntOption: Option {
     return _value != nil
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
     }
@@ -123,7 +129,7 @@ public class CounterOption: Option {
     super.init(shortFlag: shortFlag, longFlag: longFlag, required: false, helpMessage: helpMessage)
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     _value += 1
     return true
   }
@@ -141,7 +147,7 @@ public class DoubleOption: Option {
     return _value != nil
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
     }
@@ -167,7 +173,7 @@ public class StringOption: Option {
     return _value != nil
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
     }
@@ -189,7 +195,7 @@ public class MultiStringOption: Option {
     return _value != nil
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
     }
@@ -214,7 +220,7 @@ public class EnumOption<T:RawRepresentable where T.RawValue == String>: Option {
     super.init(shortFlag: shortFlag, longFlag: longFlag, required: required, helpMessage: helpMessage)
   }
   
-  override func match(values: [String]) -> Bool {
+  override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
     }

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -24,6 +24,17 @@ public class Option {
   let required: Bool
   let helpMessage: String
   
+  public var flagDescription: String {
+    switch (shortFlag, longFlag) {
+    case (let sf, let lf) where sf != nil && lf != nil:
+      return "\(ShortOptionPrefix)\(sf!), \(LongOptionPrefix)\(lf!)"
+    case (_, let lf) where lf != nil:
+      return "\(LongOptionPrefix)\(lf!)"
+    default:
+      return "\(ShortOptionPrefix)\(shortFlag)"
+    }
+  }
+  
   /* Override this property to test _value for nil on each Option subclass.
    *
    * This is necessary to support nil checks on an array of Options (see

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -536,6 +536,38 @@ internal class CommandLineTests: XCTestCase {
       XCTFail("Failed to parse mixed command line: \(error)")
     }
   }
+  
+  func testShortFlagOnlyOption() {
+    let cli = CommandLine(arguments: ["-s", "itchy", "--itchy", "scratchy"])
+    
+    let o1 = StringOption(shortFlag: "s", helpMessage: "short only")
+    let o2 = StringOption(shortFlag: "i", helpMessage: "another short")
+    cli.addOptions(o1, o2)
+    
+    do {
+      try cli.parse()
+      XCTAssertEqual(o1.value!, "itchy", "Failed to get correct string value from short-flag-only option")
+      XCTAssertNil(o2.value, "Incorrectly set value for short-flag-only option")
+    } catch {
+      XCTFail("Failed to parse short-flag-only command line: \(error)")
+    }
+  }
+  
+  func testLongFlagOnlyOption() {
+    let cli = CommandLine(arguments: ["-s", "itchy", "--itchy", "scratchy"])
+    
+    let o1 = StringOption(longFlag: "scratchy", helpMessage: "long only")
+    let o2 = StringOption(longFlag: "itchy", helpMessage: "long short")
+    cli.addOptions(o1, o2)
+    
+    do {
+      try cli.parse()
+      XCTAssertNil(o1.value, "Incorrectly set value for long-flag-only option")
+      XCTAssertEqual(o2.value!, "scratchy", "Failed to get correct string value from long-flag-only option")
+    } catch {
+      XCTFail("Failed to parse long-flag-only command line: \(error)")
+    }
+  }
 
   func testStrictMode() {
     let cli = CommandLine(arguments: [ "CommandLineTests", "--valid", "--invalid"])


### PR DESCRIPTION
In some cases, Options with only a short flag (`-f`) or long flag (`--file`) are useful.

Closes #22.