### PR TITLE
Add wasSet property to Option types

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -240,7 +240,7 @@ public class CommandLine {
     /* Check to see if any required options were not matched */
     var missingOptions: [Option] = []
     for option in _options {
-      if option.required && !option.isSet {
+      if option.required && !option.wasSet {
         missingOptions.append(option)
       }
     }

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -102,6 +102,7 @@ public class BoolOption: Option {
   
   override func setValue(values: [String]) -> Bool {
     _value = true
+    _wasSet = true
     return true
   }
 }

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -19,10 +19,15 @@
  * The base class for a command-line option.
  */
 public class Option {
-  let shortFlag: String?
-  let longFlag: String?
-  let required: Bool
-  let helpMessage: String
+  public let shortFlag: String?
+  public let longFlag: String?
+  public let required: Bool
+  public let helpMessage: String
+  
+  /** True if the option was set when parsing command-line arguments */
+  public var wasSet: Bool {
+    return false
+  }
   
   public var flagDescription: String {
     switch (shortFlag, longFlag) {
@@ -33,17 +38,6 @@ public class Option {
     default:
       return "\(ShortOptionPrefix)\(shortFlag!)"
     }
-  }
-  
-  /* Override this property to test _value for nil on each Option subclass.
-   *
-   * This is necessary to support nil checks on an array of Options (see
-   * CommandLine.parse()) because Swift doesn't allow overriding property
-   * declarations with differing types, and methods (unlike functions) are not
-   * covariant as of beta 4.
-   */
-  var isSet: Bool {
-    return false
   }
   
   private init(_ shortFlag: String?, _ longFlag: String?, _ required: Bool, _ helpMessage: String) {
@@ -96,14 +90,14 @@ public class Option {
  */
 public class BoolOption: Option {
   private var _value: Bool = false
+  private var _wasSet: Bool = false
   
   public var value: Bool {
     return _value
   }
   
-  override var isSet: Bool {
-    /* BoolOption is always set; if missing from the command line, it's false */
-    return true
+  override public var wasSet: Bool {
+    return _wasSet
   }
   
   override func setValue(values: [String]) -> Bool {
@@ -120,10 +114,10 @@ public class IntOption: Option {
     return _value
   }
   
-  override var isSet: Bool {
+  override public var wasSet: Bool {
     return _value != nil
   }
-  
+
   override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
@@ -149,9 +143,8 @@ public class CounterOption: Option {
     return _value
   }
   
-  override var isSet: Bool {
-    /* CounterOption is always set; if missing from the command line, it's 0 */
-    return true
+  override public var wasSet: Bool {
+    return _value > 0
   }
   
   override func setValue(values: [String]) -> Bool {
@@ -167,8 +160,8 @@ public class DoubleOption: Option {
   public var value: Double? {
     return _value
   }
-  
-  override var isSet: Bool {
+
+  override public var wasSet: Bool {
     return _value != nil
   }
   
@@ -194,7 +187,7 @@ public class StringOption: Option {
     return _value
   }
   
-  override var isSet: Bool {
+  override public var wasSet: Bool {
     return _value != nil
   }
   
@@ -216,7 +209,7 @@ public class MultiStringOption: Option {
     return _value
   }
   
-  override var isSet: Bool {
+  override public var wasSet: Bool {
     return _value != nil
   }
   
@@ -237,7 +230,7 @@ public class EnumOption<T:RawRepresentable where T.RawValue == String>: Option {
     return _value
   }
   
-  override var isSet: Bool {
+  override public var wasSet: Bool {
     return _value != nil
   }
   

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -90,19 +90,17 @@ public class Option {
  */
 public class BoolOption: Option {
   private var _value: Bool = false
-  private var _wasSet: Bool = false
   
   public var value: Bool {
     return _value
   }
   
   override public var wasSet: Bool {
-    return _wasSet
+    return _value
   }
   
   override func setValue(values: [String]) -> Bool {
     _value = true
-    _wasSet = true
     return true
   }
 }

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -537,6 +537,44 @@ internal class CommandLineTests: XCTestCase {
     }
   }
   
+  func testWasSetProperty() {
+    let cli = CommandLine(arguments: [ "CommandLineTests", "-a", "-b", "-c", "str", "-d", "1",
+      "-e", "3.14159", "-f", "extra1", "extra2", "extra3" ])
+    
+    let setOptions = [
+      BoolOption(shortFlag: "a", longFlag: "bool", helpMessage: "A set boolean option"),
+      CounterOption(shortFlag: "b", longFlag: "counter", helpMessage: "A set counter option"),
+      StringOption(shortFlag: "c", longFlag: "str", helpMessage: "A set string option"),
+      IntOption(shortFlag: "d", longFlag: "int", helpMessage: "A set int option"),
+      DoubleOption(shortFlag: "e", longFlag: "double", helpMessage: "A set double option"),
+      MultiStringOption(shortFlag: "f", longFlag: "multi", helpMessage: "A set multistring option")
+    ]
+    
+    let unsetOptions = [
+      BoolOption(shortFlag: "t", longFlag: "unbool", helpMessage: "An unset boolean option"),
+      CounterOption(shortFlag: "v", longFlag: "uncounter", helpMessage: "An unset counter option"),
+      StringOption(shortFlag: "w", longFlag: "unstr", helpMessage: "An unset string option"),
+      IntOption(shortFlag: "y", longFlag: "unint", helpMessage: "An unset int option"),
+      DoubleOption(shortFlag: "x", longFlag: "undouble", helpMessage: "An unset double option"),
+      MultiStringOption(shortFlag: "z", longFlag: "unmulti", helpMessage: "An unset multistring option")
+    ]
+    
+    cli.addOptions(setOptions)
+    cli.addOptions(unsetOptions)
+    
+    do {
+      try cli.parse()
+      for opt in setOptions {
+        XCTAssertTrue(opt.wasSet, "wasSet was false for set option \(opt.flagDescription)")
+      }
+      for opt in unsetOptions {
+        XCTAssertFalse(opt.wasSet, "wasSet was true for unset option \(opt.flagDescription)")
+      }
+    } catch {
+      XCTFail("Failed to parse command line with set & unset options: \(error)")
+    }
+  }
+  
   func testShortFlagOnlyOption() {
     let cli = CommandLine(arguments: ["-s", "itchy", "--itchy", "scratchy"])
     


### PR DESCRIPTION
This property lets clients determine whether or not an option was set while parsing the command line.

Closes #24.