### PR TITLE
Teach ParseError about optional short/long flag

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -71,10 +71,9 @@ public class CommandLine {
         return "Invalid argument: \(arg)"
       case let .InvalidValueForOption(opt, vals):
         let vs = ", ".join(vals)
-        return "Invalid value(s) for option \(opt.longFlag): \(vs)"
+        return "Invalid value(s) for option \(opt.flagDescription): \(vs)"
       case let .MissingRequiredOptions(opts):
-        return "Missing required options: \(opts.map { return $0.longFlag })"
-
+        return "Missing required options: \(opts.map { return $0.flagDescription })"
       }
     }
   }

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -628,6 +628,31 @@ internal class CommandLineTests: XCTestCase {
     }
   }
   
+  func testInvalidArgumentErrorDescription() {
+    let cli = CommandLine(arguments: [ "CommandLineTests", "--int", "invalid"])
+    let o1 = IntOption(longFlag: "int", helpMessage: "Int flag.")
+    cli.addOptions(o1)
+    
+    do {
+      try cli.parse()
+    } catch {
+      XCTAssertTrue("\(error)".hasSuffix("\(o1.flagDescription): invalid"), "Invalid error description: \(error)")
+    }
+  }
+  
+  func testMissingRequiredOptionsErrorDescription() {
+    let cli = CommandLine(arguments: [ "CommandLineTests"])
+    let o1 = IntOption(longFlag: "int", required: true, helpMessage: "Int flag.")
+    cli.addOptions(o1)
+    
+    do {
+      try cli.parse()
+    } catch {
+      let requiredOptions = [o1].map { return $0.flagDescription }
+      XCTAssertTrue("\(error)".hasSuffix("options: \(requiredOptions)"), "Invalid error description: \(error)")
+    }
+  }
+  
   func testPrintUsage() {
     let cli = CommandLine(arguments: [ "CommandLineTests", "-dvvv", "--name", "John Q. Public",
       "-f", "45", "-p", "0.05", "-x", "extra1", "extra2", "extra3" ])


### PR DESCRIPTION
As @beltex noticed after #25 was merged, ParseError.description looks ugly now that Option’s `shortFlag` and `longFlag` are optionals.

This fixes that up.