### PR TITLE
Update Travis builds to Xcode 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: objective-c # this is a lie
 xcode_project: CommandLine.xcodeproj
 xcode_scheme: CommandLine
 script: xcodebuild -scheme CommandLine test
-osx_image: xcode7
+osx_image: xcode7.1


### PR DESCRIPTION
Per [the Travis blog post](http://blog.travis-ci.com/2015-10-23-xcode-71-701-are-ready/).