### PR TITLE
Trailing arguments

### DIFF
--- a/CommandLine.xcodeproj/project.pbxproj
+++ b/CommandLine.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = CommandLine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.jatoben.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -458,7 +458,7 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = CommandLine/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.jatoben.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -53,7 +53,8 @@ private struct StderrOutputStream: OutputStreamType {
 public class CommandLine {
   private var _arguments: [String]
   private var _options: [Option] = [Option]()
-  
+  public private(set) var lastParsedArgumentIndex: Int = 0
+
   /** A ParseError is thrown if the `parse()` method fails. */
   public enum ParseError: ErrorType, CustomStringConvertible {
     /** Thrown if an unrecognized argument is passed to `parse()` in strict mode */
@@ -118,6 +119,7 @@ public class CommandLine {
       }
     
       args.append(_arguments[i])
+      lastParsedArgumentIndex = i
     }
     
     return args
@@ -204,6 +206,7 @@ public class CommandLine {
         }
           
         flagMatched = true
+        lastParsedArgumentIndex = idx
         break
       }
       
@@ -221,6 +224,7 @@ public class CommandLine {
             }
             
             flagMatched = true
+            lastParsedArgumentIndex = idx
             break
           }
         }

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -720,4 +720,22 @@ internal class CommandLineTests: XCTestCase {
     cli.printUsage()
     cli.printUsage(error)
   }
+
+  func testTrailingArguments() {
+    let cli = CommandLine(arguments: [ "CommandLineTests", "-xv", "file1", "file2" ])
+
+    let x = BoolOption(shortFlag: "x", longFlag: "x1", helpMessage: "")
+    let v = CounterOption(shortFlag: "v", longFlag: "v1", helpMessage: "")
+
+    cli.addOptions(x, v)
+
+    do {
+      try cli.parse()
+      XCTAssertTrue(x.value as Bool, "Failed to get true value from concat flags with value")
+      XCTAssertEqual(v.value, 1, "Failed to get correct value from concat flags with value")
+      XCTAssertEqual(cli.lastParsedArgumentIndex, 1, "Failed to get right last parsed argument index")
+    } catch {
+      XCTFail("Failed to parse trailing argument flags with value: \(error)")
+    }
+  }
 }


### PR DESCRIPTION
This allows having trailing stray arguments by adding a `lastParsedArgumentIndex` property. You are then free to do 
```swift
let args = Process.arguments
for trailingArg in args[cli.lastParsedArgumentIndex..<args.count] {
    ...
}
```