### PR TITLE
Swift 2.2 update

### DIFF
--- a/CommandLine.xcodeproj/project.pbxproj
+++ b/CommandLine.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = CommandLineTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.jatoben.${PRODUCT_NAME:rfc1034identifier}";
@@ -493,7 +493,7 @@
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
 				);
-				INFOPLIST_FILE = CommandLineTests/Info.plist;
+				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.jatoben.${PRODUCT_NAME:rfc1034identifier}";

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-/* Required for setlocale(3) */
-@_exported import Darwin
+import Darwin
 
 let ShortOptionPrefix = "-"
 let LongOptionPrefix = "--"


### PR DESCRIPTION
There were still mentions of the renamed CommandLineTests directory.
What is the purpose of importing Darwin with the undocumented @exported attribute? From what I understand, it re-exports Darwin; we can import Darwin on our own if we need it…