### PR TITLE
import Darwin normally.

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -16,7 +16,7 @@
  */
 
 /* Required for setlocale(3) */
-@exported import Darwin
+import Darwin
 
 let ShortOptionPrefix = "-"
 let LongOptionPrefix = "--"


### PR DESCRIPTION
Importing Darwin may be needed by many users of CommandLine, but not all.
If one needs Darwin or GlibC, it is easy enough to add the line to one's own code.

The justification given by the original committer (for adding the @exported attribute) is that it saves one line. That is not a good reason at all. Now it causes compatibility problems, too.