### PR TITLE
Update Travis builds to Xcode 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: objective-c # this is a lie
 xcode_project: CommandLine.xcodeproj
 xcode_scheme: CommandLine
 script: xcodebuild -scheme CommandLine test
-osx_image: xcode7.1
+osx_image: xcode7.2


### PR DESCRIPTION
Per [the Travis blog](https://blog.travis-ci.com/2015-12-10-xcode-72-is-ready).