### PR TITLE
Update to Swift 2.2-dev 2015-12-18 snapshot

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -118,8 +118,8 @@ public class CommandLine {
     if attachedArg.count > 1 {
       args.append(attachedArg[1])
     }
-    
-    for var i = flagIndex + 1; i < _arguments.count; i++ {
+
+    for i in (flagIndex + 1).stride(to: _arguments.count, by: 1) {
       if !skipFlagChecks {
         if _arguments[i] == ArgumentStopper {
           skipFlagChecks = true

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 /*
- * CommandLine.swift
+ * Package.swift
  * Copyright (c) 2015 Ben Gollmer.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 
- import PackageDescription
+import PackageDescription
 
- let package = Package(name: "CommandLine")
+let package = Package(name: "CommandLine", exclude: ["CommandLineTests"])
 
- #if os(Linux)
- let target = Target(name: "CommandLineTests", dependencies: [.Target(name: "CommandLine")])
- package.targets.append(target)
- #endif
+let target = Target(name: "CommandLineTests", dependencies: [.Target(name: "CommandLine")])
+package.targets.append(target)
+

--- a/install-linux-swift.sh
+++ b/install-linux-swift.sh
@@ -13,4 +13,5 @@ tar -zxvf "${SWIFT_SNAPSHOT}.tar.gz"
 cd "swift-corelibs-xctest-${SWIFT_SNAPSHOT}"
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 cd ..
+rm -rf "swift-corelibs-xctest-${SWIFT_SNAPSHOT}"
 

--- a/install-linux-swift.sh
+++ b/install-linux-swift.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-SWIFT_SNAPSHOT="swift-2.2-SNAPSHOT-2015-12-10-a"
+SWIFT_SNAPSHOT="swift-2.2-SNAPSHOT-2015-12-18-a"
 
 echo "Installing ${SWIFT_SNAPSHOT}..."
 curl -s -L -O "https://swift.org/builds/ubuntu1404/${SWIFT_SNAPSHOT}/${SWIFT_SNAPSHOT}-ubuntu14.04.tar.gz"


### PR DESCRIPTION
Fairly minor changes in this snapshot. [Four tests](https://github.com/jatoben/CommandLine/blob/swift-2015-12-18/CommandLineTests/CommandLineTests.swift#L30-L55) still segfault on Linux :cry: 