### PR TITLE
Update to Swift 2.2-dev 2015-12-31 snapshot

### DIFF
--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -24,7 +24,7 @@ import XCTest
 #endif
 
 internal class CommandLineTests: XCTestCase {
-  /* TODO: The commented-out tests segfault on Linux as of the Swift 2.2 2015-12-10 snapshot. */
+  /* TODO: The commented-out tests segfault on Linux as of the Swift 2.2 2015-12-31 snapshot. */
   var allTests : [(String, () -> ())] {
     return [
       ("testBoolOptions", testBoolOptions),

--- a/CommandLineTests/StringExtensionTests.swift
+++ b/CommandLineTests/StringExtensionTests.swift
@@ -24,7 +24,7 @@ import XCTest
 #endif
 
 class StringExtensionTests: XCTestCase {
-  /* TODO: The commented-out tests segfault on Linux as of the Swift 2.2 2015-12-10 snapshot. */
+  /* TODO: The commented-out tests segfault on Linux as of the Swift 2.2 2015-12-31 snapshot. */
   var allTests : [(String, () -> ())] {
     return [
       //("testToDouble", testToDouble),

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,7 @@
 
 import PackageDescription
 
-let package = Package(name: "CommandLine", exclude: ["CommandLineTests"])
+let package = Package(name: "CommandLine")
 
 let target = Target(name: "CommandLineTests", dependencies: [.Target(name: "CommandLine")])
 package.targets.append(target)
-

--- a/install-linux-swift.sh
+++ b/install-linux-swift.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-SWIFT_SNAPSHOT="swift-2.2-SNAPSHOT-2015-12-18-a"
+SWIFT_SNAPSHOT="swift-2.2-SNAPSHOT-2015-12-31-a"
 
 echo "Installing ${SWIFT_SNAPSHOT}..."
 curl -s -L -O "https://swift.org/builds/ubuntu1404/${SWIFT_SNAPSHOT}/${SWIFT_SNAPSHOT}-ubuntu14.04.tar.gz"
@@ -14,4 +14,3 @@ cd "swift-corelibs-xctest-${SWIFT_SNAPSHOT}"
 ./build_script.py --swiftc="/swift/usr/bin/swiftc" --build-dir="/tmp/XCTest_build" --swift-build-dir="/swift/usr" --library-install-path="/swift/usr/lib/swift/linux" --module-install-path="/swift/usr/lib/swift/linux/x86_64"
 cd ..
 rm -rf "swift-corelibs-xctest-${SWIFT_SNAPSHOT}"
-


### PR DESCRIPTION
Segfaults still persist for the same tests, everything else is :green_apple: 