### PR TITLE
Remove C-isms

### DIFF
--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -91,12 +91,12 @@ internal extension String {
     var numSplits = 0
 
     var curIdx = self.startIndex
-    for(var i = self.startIndex; i != self.endIndex; i = i.successor()) {
+    for i in self.characters.indices {
       let c = self[i]
       if c == splitBy && (maxSplits == 0 || numSplits < maxSplits) {
         s.append(self[Range(start: curIdx, end: i)])
         curIdx = i.successor()
-        numSplits++
+        numSplits += 1
       }
     }
 
@@ -119,8 +119,9 @@ internal extension String {
     var s = self
     var currentLength = self.characters.count
 
-    while currentLength++ < width {
+    while currentLength < width {
       s.append(padBy)
+      currentLength += 1
     }
 
     return s


### PR DESCRIPTION
Fix some warnings from the Swift 2.2 compiler.

The whole _StringExtensions.swift_ file could probably use a good Swifty refactoring, but this is just a minor change for now.