### PR TITLE
Add custom output formatter

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -57,6 +57,7 @@ private struct StderrOutputStream: OutputStreamType {
 public class CommandLine {
   private var _arguments: [String]
   private var _options: [Option] = [Option]()
+  private var _maxFlagWidth: Int = 0
   private var _usedFlags: Set<String> {
     var usedFlags = Set<String>(minimumCapacity: _options.count * 2)
 
@@ -68,7 +69,67 @@ public class CommandLine {
 
     return usedFlags
   }
-  
+
+  /**
+   * If supplied, this function will be called when printing usage messages.
+   *
+   * You can use the `defaultFormat` function to get the normally-formatted
+   * output, either before or after modifying the provided string. For example:
+   *
+   * ```
+   * let cli = CommandLine()
+   * cli.formatOutput = { str, type in
+   *   switch(type) {
+   *   case .Error:
+   *     // Make errors shouty
+   *     return defaultFormat(str.uppercaseString, type: type)
+   *   case .OptionHelp:
+   *     // Don't use the default indenting
+   *     return ">> \(s)\n"
+   *   default:
+   *     return defaultFormat(str, type: type)
+   *   }
+   * }
+   * ```
+   *
+   * - note: Newlines are not appended to the result of this function. If you don't use
+   * `defaultFormat()`, be sure to add them before returning.
+   */
+  public var formatOutput: ((String, OutputType) -> String)?
+
+  /**
+   * The maximum width of all options' `flagDescription` properties; provided for use by
+   * output formatters.
+   *
+   * - seealso: `defaultFormat`, `formatOutput`
+   */
+  public var maxFlagWidth: Int {
+    if _maxFlagWidth == 0 {
+      _maxFlagWidth = _options.map { $0.flagDescription.characters.count }.sort().first ?? 0
+    }
+
+    return _maxFlagWidth
+  }
+
+  /**
+   * The type of output being supplied to an output formatter.
+   *
+   * - seealso: `formatOutput`
+   */
+  public enum OutputType {
+    /** About text: `Usage: command-example [options]` and the like */
+    case About
+
+    /** An error message: `Missing required option --extract`  */
+    case Error
+
+    /** An Option's `flagDescription`: `-h, --help:` */
+    case OptionFlag
+
+    /** An Option's help message */
+    case OptionHelp
+  }
+
   /** A ParseError is thrown if the `parse()` method fails. */
   public enum ParseError: ErrorType, CustomStringConvertible {
     /** Thrown if an unrecognized argument is passed to `parse()` in strict mode */
@@ -150,6 +211,7 @@ public class CommandLine {
     }
 
     _options.append(option)
+    _maxFlagWidth = 0
   }
   
   /**
@@ -195,10 +257,15 @@ public class CommandLine {
   }
   
   /**
-   * Parses command-line arguments into their matching Option values. Throws `ParseError` if
-   * argument parsing fails.
+   * Parses command-line arguments into their matching Option values.
    *
    * - parameter strict: Fail if any unrecognized arguments are present (default: false).
+   *
+   * - throws: A `ParseError` if argument parsing fails:
+   *   - `.InvalidArgument` if an unrecognized flag is present and `strict` is true
+   *   - `.InvalidValueForOption` if the value supplied to an option is not valid (for
+   *     example, a string is supplied for an IntOption)
+   *   - `.MissingRequiredOptions` if a required option isn't present
    */
   public func parse(strict: Bool = false) throws {
     for (idx, arg) in _arguments.enumerate() {
@@ -264,28 +331,48 @@ public class CommandLine {
       throw ParseError.MissingRequiredOptions(missingOptions)
     }
   }
-  
+
+  /**
+   * Provides the default formatting of `printUsage()` output.
+   *
+   * - parameter s:     The string to format.
+   * - parameter type:  Type of output.
+   *
+   * - returns: The formatted string.
+   * - seealso: `formatOutput`
+   */
+  public func defaultFormat(s: String, type: OutputType) -> String {
+    switch type {
+    case .About:
+      return "\(s)\n"
+    case .Error:
+      return "\(s)\n\n"
+    case .OptionFlag:
+      return "  \(s.paddedToWidth(maxFlagWidth)):\n"
+    case .OptionHelp:
+      return "      \(s)\n"
+    }
+  }
+
   /* printUsage() is generic for OutputStreamType because the Swift compiler crashes
    * on inout protocol function parameters in Xcode 7 beta 1 (rdar://21372694).
    */
-  
+
   /**
    * Prints a usage message.
    * 
    * - parameter to: An OutputStreamType to write the error message to.
    */
   public func printUsage<TargetStream: OutputStreamType>(inout to: TargetStream) {
-    let name = _arguments[0]
-    
-    var flagWidth = 0
-    for opt in _options {
-      flagWidth = max(flagWidth, "  \(opt.flagDescription):".characters.count)
-    }
+    /* Nil coalescing operator (??) doesn't work on closures :( */
+    let format = formatOutput != nil ? formatOutput! : defaultFormat
 
-    print("Usage: \(name) [options]", toStream: &to)
+    let name = _arguments[0]
+    print(format("Usage: \(name) [options]", .About), terminator: "", toStream: &to)
+
     for opt in _options {
-      let flags = "  \(opt.flagDescription):".paddedToWidth(flagWidth)
-      print("\(flags)\n      \(opt.helpMessage)", toStream: &to)
+      print(format(opt.flagDescription, .OptionFlag), terminator: "", toStream: &to)
+      print(format(opt.helpMessage, .OptionHelp), terminator: "", toStream: &to)
     }
   }
   
@@ -297,7 +384,8 @@ public class CommandLine {
    * - parameter to: An OutputStreamType to write the error message to.
    */
   public func printUsage<TargetStream: OutputStreamType>(error: ErrorType, inout to: TargetStream) {
-    print("\(error)\n", toStream: &to)
+    let format = formatOutput != nil ? formatOutput! : defaultFormat
+    print(format("\(error)", .Error), terminator: "", toStream: &to)
     printUsage(&to)
   }
   

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -57,7 +57,7 @@ private struct StderrOutputStream: OutputStreamType {
 public class CommandLine {
   private var _arguments: [String]
   private var _options: [Option] = [Option]()
-  private var _maxFlagWidth: Int = 0
+  private var _maxFlagDescriptionWidth: Int = 0
   private var _usedFlags: Set<String> {
     var usedFlags = Set<String>(minimumCapacity: _options.count * 2)
 
@@ -103,12 +103,12 @@ public class CommandLine {
    *
    * - seealso: `defaultFormat`, `formatOutput`
    */
-  public var maxFlagWidth: Int {
-    if _maxFlagWidth == 0 {
-      _maxFlagWidth = _options.map { $0.flagDescription.characters.count }.sort().first ?? 0
+  public var maxFlagDescriptionWidth: Int {
+    if _maxFlagDescriptionWidth == 0 {
+      _maxFlagDescriptionWidth = _options.map { $0.flagDescription.characters.count }.sort().first ?? 0
     }
 
-    return _maxFlagWidth
+    return _maxFlagDescriptionWidth
   }
 
   /**
@@ -211,7 +211,7 @@ public class CommandLine {
     }
 
     _options.append(option)
-    _maxFlagWidth = 0
+    _maxFlagDescriptionWidth = 0
   }
   
   /**
@@ -348,7 +348,7 @@ public class CommandLine {
     case .Error:
       return "\(s)\n\n"
     case .OptionFlag:
-      return "  \(s.paddedToWidth(maxFlagWidth)):\n"
+      return "  \(s.paddedToWidth(maxFlagDescriptionWidth)):\n"
     case .OptionHelp:
       return "      \(s)\n"
     }

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -53,6 +53,7 @@ internal class CommandLineTests: XCTestCase {
       ("testPrintUsage", testPrintUsage),
       //("testPrintUsageError", testPrintUsageError),
       ("testPrintUsageToStderr", testPrintUsageToStderr),
+      ("testCustomOutputFormatter", testCustomOutputFormatter),
     ]
   }
 

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -53,7 +53,7 @@ internal class CommandLineTests: XCTestCase {
       ("testPrintUsage", testPrintUsage),
       //("testPrintUsageError", testPrintUsageError),
       ("testPrintUsageToStderr", testPrintUsageToStderr),
-      ("testCustomOutputFormatter", testCustomOutputFormatter),
+      //("testCustomOutputFormatter", testCustomOutputFormatter),
     ]
   }
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Usage: example [options]
 
 You can fully customize the usage message by supplying a `formatOutput` function. For example, [Rainbow](https://github.com/onevcat/Rainbow) provides a handy way to generate colorized output:
 
-```
+```swift
 import Rainbow
 
 cli.formatOutput = { s, type in

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-CommandLine [![Build Status](https://travis-ci.org/jatoben/CommandLine.svg?branch=master)](https://travis-ci.org/jatoben/CommandLine)
-===========
+# CommandLine [![Build Status](https://travis-ci.org/jatoben/CommandLine.svg?branch=master)](https://travis-ci.org/jatoben/CommandLine)
+
 A pure Swift library for creating command-line interfaces.
 
 *Note: CommandLine `master` requires Xcode 7  / Swift 2.0, and aims to support the latest 2.2-dev snapshot on Linux (although not all tests pass yet). If you're using older versions of Swift, please check out the [earlier releases](https://github.com/jatoben/CommandLine/releases).*
 
-Usage
------
+## Usage
+
 CommandLine aims to have a simple and self-explanatory API.
 
 ```swift
@@ -45,8 +45,7 @@ If you are building a command-line tool and need to embed this and other framewo
 If you are building a standalone command-line tool, you'll need to add the CommandLine source files directly to your target, because Xcode [can't yet build static libraries that contain Swift code](https://github.com/ksm/SwiftInFlux#static-libraries).
 
 
-Features
---------
+## Features
 
 ### Automatically generated usage messages
 
@@ -61,6 +60,30 @@ Usage: example [options]
   -v, --verbose:
       Print verbose messages. Specify multiple times to increase verbosity.
 ```
+
+You can fully customize the usage message by supplying a `formatOutput` function. For example, [Rainbow](https://github.com/onevcat/Rainbow) provides a handy way to generate colorized output:
+
+```
+import Rainbow
+
+cli.formatOutput = { s, type in
+  var str: String
+  switch(type) {
+  case .Error:
+    str = s.red.bold
+  case .OptionFlag:
+    str = s.green.underline
+  case .OptionHelp:
+    str = s.blue
+  default:
+    str = s
+  }
+
+  return cli.defaultFormat(str, type: type)
+}
+```
+
+![](https://cloud.githubusercontent.com/assets/318083/12108437/1e3ec25c-b335-11e5-9cc9-d45ad3ab3dc7.png)
 
 ### Supports all common flag styles
 


### PR DESCRIPTION
Allow users to supply a custom `formatOutput` function. This lets folks customize the usage message output in a simple way without taking a dependency on any specific libraries.

Closes #33.

/cc @beltex 