### PR TITLE
Add support for stray values

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -70,6 +70,28 @@ public class CommandLine {
     return usedFlags
   }
 
+  /**
+   * After calling `parse()`, this property will contain any values that weren't captured
+   * by an Option. For example:
+   *
+   * ```
+   * let cli = CommandLine()
+   * let fileType = StringOption(shortFlag: "t", longFlag: "type", required: true, helpMessage: "Type of file")
+   *
+   * do {
+   *   try cli.parse()
+   *   print("File type is \(type), files are \(cli.strayValues)")
+   * catch {
+   *   cli.printUsage(error)
+   *   exit(EX_USAGE)
+   * }
+   *
+   * ---
+   *
+   * $ ./readfiles --type=pdf ~/file1.pdf ~/file2.pdf
+   * File type is pdf, files are ["~/file1.pdf", "~/file2.pdf"]
+   * ```
+   */
   public private(set) var strayValues: [String] = [String]()
 
   /**

--- a/CommandLine/Option.swift
+++ b/CommandLine/Option.swift
@@ -28,7 +28,9 @@ public class Option {
   public var wasSet: Bool {
     return false
   }
-  
+
+  public var claimedValues: Int { return 0 }
+
   public var flagDescription: String {
     switch (shortFlag, longFlag) {
     case let (.Some(sf), .Some(lf)):
@@ -119,6 +121,10 @@ public class IntOption: Option {
     return _value != nil
   }
 
+  override public var claimedValues: Int {
+    return _value != nil ? 1 : 0
+  }
+
   override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
@@ -147,6 +153,10 @@ public class CounterOption: Option {
   override public var wasSet: Bool {
     return _value > 0
   }
+
+  public func reset() {
+    _value = 0
+  }
   
   override func setValue(values: [String]) -> Bool {
     _value += 1
@@ -165,7 +175,11 @@ public class DoubleOption: Option {
   override public var wasSet: Bool {
     return _value != nil
   }
-  
+
+  override public var claimedValues: Int {
+    return _value != nil ? 1 : 0
+  }
+
   override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
@@ -191,7 +205,11 @@ public class StringOption: Option {
   override public var wasSet: Bool {
     return _value != nil
   }
-  
+
+  override public var claimedValues: Int {
+    return _value != nil ? 1 : 0
+  }
+
   override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
@@ -213,7 +231,15 @@ public class MultiStringOption: Option {
   override public var wasSet: Bool {
     return _value != nil
   }
-  
+
+  override public var claimedValues: Int {
+    if let v = _value {
+      return v.count
+    }
+
+    return 0
+  }
+
   override func setValue(values: [String]) -> Bool {
     if values.count == 0 {
       return false
@@ -234,7 +260,11 @@ public class EnumOption<T:RawRepresentable where T.RawValue == String>: Option {
   override public var wasSet: Bool {
     return _value != nil
   }
-  
+
+  override public var claimedValues: Int {
+    return _value != nil ? 1 : 0
+  }
+
   /* Re-defining the intializers is necessary to make the Swift 2 compiler happy, as
    * of Xcode 7 beta 2.
    */

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -708,15 +708,16 @@ internal class CommandLineTests: XCTestCase {
   }
 
   func testStrayValues() {
-    let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "--formats=json", "xml", "binary", "--verbose", "fish"])
+    let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "--formats=json", "xml", "binary", "--verbose", "fish", "--type=pdf", "woo!"])
     let o1 = BoolOption(shortFlag: "b", longFlag: "bool", helpMessage: "Boolean option")
     let o2 = StringOption(shortFlag: "c", longFlag: "color", helpMessage: "String option")
     let o3 = BoolOption(shortFlag: "x", longFlag: "extract", helpMessage: "Combined bool option")
     let o4 = CounterOption(shortFlag: "v", longFlag: "verbose", helpMessage: "Combined counter option")
     let o5 = IntOption(shortFlag: "i", longFlag: "int", helpMessage: "Combined int option")
     let o6 = MultiStringOption(shortFlag: "f", longFlag: "formats", helpMessage: "Attached multistring option")
+    let o7 = StringOption(shortFlag: "t", longFlag: "type", helpMessage: "Attached string option")
 
-    cli.addOptions(o1, o2, o3, o4, o5, o6)
+    cli.addOptions(o1, o2, o3, o4, o5, o6, o7)
 
     do {
       try cli.parse()
@@ -725,8 +726,9 @@ internal class CommandLineTests: XCTestCase {
       XCTAssertTrue(o3.value, "Failed to set combined bool option with stray values")
       XCTAssertEqual(o4.value, 3, "Incorrect value for combined counter option with stray values")
       XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
-      XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached string option with stray values")
-      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish"], "Incorrect stray values")
+      XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached multistring option with stray values")
+      XCTAssertEqual(o7.value!, "pdf", "Incorrect value for attached string option with stray values")
+      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish", "woo!"], "Incorrect stray values")
     } catch {
       XCTFail("Unexpected parse error: \(error)")
     }
@@ -740,8 +742,9 @@ internal class CommandLineTests: XCTestCase {
       XCTAssertTrue(o3.value, "Failed to set combined bool option with stray values")
       XCTAssertEqual(o4.value, 3, "Incorrect value for combined counter option with stray values")
       XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
-      XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached string option with stray values")
-      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish"], "Incorrect stray values")
+      XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached multistring option with stray values")
+      XCTAssertEqual(o7.value!, "pdf", "Incorrect value for attached string option with stray values")
+      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish", "woo!"], "Incorrect stray values")
     } catch {
       XCTFail("Stray values should not cause a throw in strict mode")
     }

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -48,6 +48,7 @@ internal class CommandLineTests: XCTestCase {
       ("testShortFlagOnlyOption", testShortFlagOnlyOption),
       ("testLongFlagOnlyOption", testLongFlagOnlyOption),
       ("testStrictMode", testStrictMode),
+      ("testStrayValues", testStrayValues),
       //("testInvalidArgumentErrorDescription", testInvalidArgumentErrorDescription),
       //("testMissingRequiredOptionsErrorDescription", testMissingRequiredOptionsErrorDescription),
       ("testPrintUsage", testPrintUsage),
@@ -703,6 +704,46 @@ internal class CommandLineTests: XCTestCase {
       XCTAssertEqual(arg, "--invalid", "Incorrect argument identified in InvalidArgument: \(arg)")
     } catch {
       XCTFail("Unexpected parse error: \(error)")
+    }
+  }
+
+  func testStrayValues() {
+    let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "--formats=json", "xml", "binary", "--verbose", "fish"])
+    let o1 = BoolOption(shortFlag: "b", longFlag: "bool", helpMessage: "Boolean option")
+    let o2 = StringOption(shortFlag: "c", longFlag: "color", helpMessage: "String option")
+    let o3 = BoolOption(shortFlag: "x", longFlag: "extract", helpMessage: "Combined bool option")
+    let o4 = CounterOption(shortFlag: "v", longFlag: "verbose", helpMessage: "Combined counter option")
+    let o5 = IntOption(shortFlag: "i", longFlag: "int", helpMessage: "Combined int option")
+    let o6 = MultiStringOption(shortFlag: "f", longFlag: "formats", helpMessage: "Attached multistring option")
+
+    cli.addOptions(o1, o2, o3, o4, o5, o6)
+
+    do {
+      try cli.parse()
+      XCTAssertTrue(o1.value, "Failed to set bool option with stray values")
+      XCTAssertEqual(o2.value!, "green", "Incorrect value for string option with stray values")
+      XCTAssertTrue(o3.value, "Failed to set combined bool option with stray values")
+      XCTAssertEqual(o4.value, 3, "Incorrect value for combined counter option with stray values")
+      XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
+      XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached string option with stray values")
+      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish"], "Incorrect stray values")
+    } catch {
+      XCTFail("Unexpected parse error: \(error)")
+    }
+
+    do {
+      o4.reset()
+
+      try cli.parse(true)
+      XCTAssertTrue(o1.value, "Failed to set bool option with stray values")
+      XCTAssertEqual(o2.value!, "green", "Incorrect value for string option with stray values")
+      XCTAssertTrue(o3.value, "Failed to set combined bool option with stray values")
+      XCTAssertEqual(o4.value, 3, "Incorrect value for combined counter option with stray values")
+      XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
+      XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached string option with stray values")
+      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish"], "Incorrect stray values")
+    } catch {
+      XCTFail("Stray values should not cause a throw in strict mode")
     }
   }
 

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -708,7 +708,7 @@ internal class CommandLineTests: XCTestCase {
   }
 
   func testStrayValues() {
-    let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "--formats=json", "xml", "binary", "--verbose", "fish", "--type=pdf", "woo!"])
+    let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "-w", "--who", "--formats=json", "xml", "binary", "--verbose", "fish", "--type=pdf", "woo!"])
     let o1 = BoolOption(shortFlag: "b", longFlag: "bool", helpMessage: "Boolean option")
     let o2 = StringOption(shortFlag: "c", longFlag: "color", helpMessage: "String option")
     let o3 = BoolOption(shortFlag: "x", longFlag: "extract", helpMessage: "Combined bool option")
@@ -728,13 +728,15 @@ internal class CommandLineTests: XCTestCase {
       XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
       XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached multistring option with stray values")
       XCTAssertEqual(o7.value!, "pdf", "Incorrect value for attached string option with stray values")
-      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish", "woo!"], "Incorrect stray values")
+      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "-w", "--who", "fish", "woo!"], "Incorrect stray values")
     } catch {
       XCTFail("Unexpected parse error: \(error)")
     }
 
     do {
+      let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "--formats=json", "xml", "binary", "--verbose", "fish", "--type=pdf", "woo!"])
       o4.reset()
+      cli.addOptions(o1, o2, o3, o4, o5, o6, o7)
 
       try cli.parse(true)
       XCTAssertTrue(o1.value, "Failed to set bool option with stray values")


### PR DESCRIPTION
Captures stray values when parsing the command line, and makes them available in the `strayValues` property.

Closes #23.