### PR TITLE
Implicit Range initialization

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -307,7 +307,7 @@ public class CommandLine {
       
       let skipChars = arg.hasPrefix(LongOptionPrefix) ?
         LongOptionPrefix.characters.count : ShortOptionPrefix.characters.count
-      let flagWithArg = arg[Range(start: arg.startIndex.advancedBy(skipChars), end: arg.endIndex)]
+      let flagWithArg = arg[arg.startIndex.advancedBy(skipChars)..<arg.endIndex]
       
       /* The argument contained nothing but ShortOptionPrefix or LongOptionPrefix */
       if flagWithArg.isEmpty {

--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -94,14 +94,14 @@ internal extension String {
     for i in self.characters.indices {
       let c = self[i]
       if c == splitBy && (maxSplits == 0 || numSplits < maxSplits) {
-        s.append(self[Range(start: curIdx, end: i)])
+        s.append(self[curIdx..<i])
         curIdx = i.successor()
         numSplits += 1
       }
     }
 
     if curIdx != self.endIndex {
-      s.append(self[Range(start: curIdx, end: self.endIndex)])
+      s.append(self[curIdx..<self.endIndex])
     }
 
     return s


### PR DESCRIPTION
These `Range` initializers are deprecated; replaced them by the `..<` operator.