### PR TITLE
Rename strayValues to unparsed

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -291,10 +291,10 @@ public class CommandLine {
    */
   public func parse(strict: Bool = false) throws {
     /* Kind of an ugly cast here */
-    var strays = _arguments.map { $0 as String? }
+    var strays = _arguments
 
     /* Nuke executable name */
-    strays[0] = nil
+    strays[0] = ""
 
     for (idx, arg) in _arguments.enumerate() {
       if arg == ArgumentStopper {
@@ -329,7 +329,7 @@ public class CommandLine {
         var claimedIdx = idx + option.claimedValues
         if attachedArg != nil { claimedIdx -= 1 }
         for i in idx.stride(through: claimedIdx, by: 1) {
-          strays[i] = nil
+          strays[i] = ""
         }
 
         flagMatched = true
@@ -352,7 +352,7 @@ public class CommandLine {
             var claimedIdx = idx + option.claimedValues
             if attachedArg != nil { claimedIdx -= 1 }
             for i in idx.stride(through: claimedIdx, by: 1) {
-              strays[i] = nil
+              strays[i] = ""
             }
             
             flagMatched = true
@@ -373,7 +373,7 @@ public class CommandLine {
       throw ParseError.MissingRequiredOptions(missingOptions)
     }
 
-    strayValues = strays.flatMap { $0 }
+    unparsed = strays.filter { $0 != "" }
   }
 
   /**

--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -80,7 +80,7 @@ public class CommandLine {
    *
    * do {
    *   try cli.parse()
-   *   print("File type is \(type), files are \(cli.strayValues)")
+   *   print("File type is \(type), files are \(cli.unparsed)")
    * catch {
    *   cli.printUsage(error)
    *   exit(EX_USAGE)
@@ -92,7 +92,7 @@ public class CommandLine {
    * File type is pdf, files are ["~/file1.pdf", "~/file2.pdf"]
    * ```
    */
-  public private(set) var strayValues: [String] = [String]()
+  public private(set) var unparsed: [String] = [String]()
 
   /**
    * If supplied, this function will be called when printing usage messages.

--- a/CommandLineTests/CommandLineTests.swift
+++ b/CommandLineTests/CommandLineTests.swift
@@ -48,7 +48,7 @@ internal class CommandLineTests: XCTestCase {
       ("testShortFlagOnlyOption", testShortFlagOnlyOption),
       ("testLongFlagOnlyOption", testLongFlagOnlyOption),
       ("testStrictMode", testStrictMode),
-      ("testStrayValues", testStrayValues),
+      ("testUnparsed", testUnparsed),
       //("testInvalidArgumentErrorDescription", testInvalidArgumentErrorDescription),
       //("testMissingRequiredOptionsErrorDescription", testMissingRequiredOptionsErrorDescription),
       ("testPrintUsage", testPrintUsage),
@@ -707,7 +707,7 @@ internal class CommandLineTests: XCTestCase {
     }
   }
 
-  func testStrayValues() {
+  func testUnparsed() {
     let cli = CommandLine(arguments: [ "CommandLineTests", "onefish", "twofish", "-b", "redfish", "-c", "green", "blue", "-xvvi", "9", "-w", "--who", "--formats=json", "xml", "binary", "--verbose", "fish", "--type=pdf", "woo!"])
     let o1 = BoolOption(shortFlag: "b", longFlag: "bool", helpMessage: "Boolean option")
     let o2 = StringOption(shortFlag: "c", longFlag: "color", helpMessage: "String option")
@@ -728,7 +728,7 @@ internal class CommandLineTests: XCTestCase {
       XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
       XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached multistring option with stray values")
       XCTAssertEqual(o7.value!, "pdf", "Incorrect value for attached string option with stray values")
-      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "-w", "--who", "fish", "woo!"], "Incorrect stray values")
+      XCTAssertEqual(cli.unparsed, ["onefish", "twofish", "redfish", "blue", "-w", "--who", "fish", "woo!"], "Incorrect unparsed values")
     } catch {
       XCTFail("Unexpected parse error: \(error)")
     }
@@ -746,7 +746,7 @@ internal class CommandLineTests: XCTestCase {
       XCTAssertEqual(o5.value!, 9, "Incorrect value for combined int option with stray values")
       XCTAssertEqual(o6.value!, ["json", "xml", "binary"], "Incorrect value for attached multistring option with stray values")
       XCTAssertEqual(o7.value!, "pdf", "Incorrect value for attached string option with stray values")
-      XCTAssertEqual(cli.strayValues, ["onefish", "twofish", "redfish", "blue", "fish", "woo!"], "Incorrect stray values")
+      XCTAssertEqual(cli.unparsed, ["onefish", "twofish", "redfish", "blue", "fish", "woo!"], "Incorrect unparsed values")
     } catch {
       XCTFail("Stray values should not cause a throw in strict mode")
     }


### PR DESCRIPTION
`strayValues` is not a particularly good name. I'm suggesting `unparsed`.
Also, minor tweak to avoid elevating to and flattening from `Optional` in the `parse` function.