### PR TITLE
Make DEVELOPMENT-SNAPSHOT-2016-03-16-a API changes

### DIFF
--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -29,9 +29,9 @@ internal extension String {
   private func _localDecimalPoint() -> Character {
     let locale = localeconv()
     if locale != nil {
-      let decimalPoint = locale.memory.decimal_point
+      let decimalPoint = locale.pointee.decimal_point
       if decimalPoint != nil {
-        return Character(UnicodeScalar(UInt32(decimalPoint.memory)))
+        return Character(UnicodeScalar(UInt32(decimalPoint.pointee)))
       }
     }
 
@@ -50,7 +50,7 @@ internal extension String {
     var isNegative: Bool = false
     let decimalPoint = self._localDecimalPoint()
 
-    for (i, c) in self.characters.enumerate() {
+    for (i, c) in self.characters.enumerated() {
       if i == 0 && c == "-" {
         isNegative = true
         continue


### PR DESCRIPTION
I made the changes to allow this to work with Swift development snapshot 2016-03-16-a (also working for 2016-03-24-a). This is Swift 3.0 dev.

This has not been extensively tested, but the little bit I've been using has worked fine. Not sure if you want to support Swift 3.0 yet, but I thought I'd submit this just in case.