### PR TITLE
Clean up StringExtensions style

### DIFF
--- a/CommandLine/CommandLine.swift
+++ b/CommandLine/CommandLine.swift
@@ -453,7 +453,7 @@ public class CommandLine {
       }
       
       /* Remove attached argument from flag */
-      let splitFlag = flagWithArg.splitByCharacter(ArgumentAttacher, maxSplits: 1)
+      let splitFlag = flagWithArg.split(by: ArgumentAttacher, maxSplits: 1)
       let flag = splitFlag[0]
       let attachedArg: String? = splitFlag.count == 2 ? splitFlag[1] : nil
       
@@ -535,7 +535,7 @@ public class CommandLine {
     case .Error:
       return "\(s)\n\n"
     case .OptionFlag:
-      return "  \(s.paddedToWidth(maxFlagDescriptionWidth)):\n"
+      return "  \(s.padded(toWidth: maxFlagDescriptionWidth)):\n"
     case .OptionHelp:
       return "      \(s)\n"
     }

--- a/CommandLine/StringExtensions.swift
+++ b/CommandLine/StringExtensions.swift
@@ -89,23 +89,23 @@ internal extension String {
       (isNegative ? -1 : 1)
   }
 
+  #if swift(>=3.0)
   /**
    * Splits a string into an array of string components.
    *
-   * - parameter splitBy:  The character to split on.
-   * - parameter maxSplit: The maximum number of splits to perform. If 0, all possible splits are made.
+   * - parameter by:        The character to split on.
+   * - parameter maxSplits: The maximum number of splits to perform. If 0, all possible splits are made.
    *
    * - returns: An array of string components.
    */
-  #if swift(>=3.0)
-  func splitByCharacter(_ splitBy: Character, maxSplits: Int = 0) -> [String] {
+  func split(by: Character, maxSplits: Int = 0) -> [String] {
     var s = [String]()
     var numSplits = 0
 
     var curIdx = self.startIndex
     for i in self.characters.indices {
       let c = self[i]
-      if c == splitBy && (maxSplits == 0 || numSplits < maxSplits) {
+      if c == by && (maxSplits == 0 || numSplits < maxSplits) {
         s.append(self[curIdx..<i])
         curIdx = self.index(after: i)
         numSplits += 1
@@ -118,15 +118,25 @@ internal extension String {
 
     return s
   }
+
   #else
-  func splitByCharacter(splitBy: Character, maxSplits: Int = 0) -> [String] {
+
+  /**
+   * Splits a string into an array of string components.
+   *
+   * - parameter by:        The character to split on.
+   * - parameter maxSplits: The maximum number of splits to perform. If 0, all possible splits are made.
+   *
+   * - returns: An array of string components.
+   */
+  func split(by by: Character, maxSplits: Int = 0) -> [String] {
     var s = [String]()
     var numSplits = 0
 
     var curIdx = self.startIndex
     for i in self.characters.indices {
       let c = self[i]
-      if c == splitBy && (maxSplits == 0 || numSplits < maxSplits) {
+      if c == by && (maxSplits == 0 || numSplits < maxSplits) {
         s.append(self[curIdx..<i])
         curIdx = i.successor()
         numSplits += 1
@@ -139,23 +149,23 @@ internal extension String {
 
     return s
   }
+
   #endif
 
   /**
    * Pads a string to the specified width.
    *
-   * - parameter width: The width to pad the string to.
-   * - parameter padBy: The character to use for padding.
+   * - parameter toWidth: The width to pad the string to.
+   * - parameter by: The character to use for padding.
    *
    * - returns: A new string, padded to the given width.
    */
-  #if swift(>=3.0)
-  func paddedToWidth(_ width: Int, padBy: Character = " ") -> String {
+  func padded(toWidth width: Int, with padChar: Character = " ") -> String {
     var s = self
     var currentLength = self.characters.count
 
     while currentLength < width {
-      s.append(padBy)
+      s.append(padChar)
       currentLength += 1
     }
 
@@ -169,17 +179,17 @@ internal extension String {
    * If a single word is longer than the line width, it will be placed (unsplit)
    * on a line by itself.
    *
-   * - parameter width:   The maximum length of a line.
+   * - parameter atWidth:   The maximum length of a line.
    * - parameter wrapBy:  The line break character to use.
    * - parameter splitBy: The character to use when splitting the string into words.
    *
    * - returns: A new string, wrapped at the given width.
    */
-  func wrappedAtWidth(_ width: Int, wrapBy: Character = "\n", splitBy: Character = " ") -> String {
+  func wrapped(atWidth width: Int, wrapBy: Character = "\n", splitBy: Character = " ") -> String {
     var s = ""
     var currentLineWidth = 0
 
-    for word in self.splitByCharacter(splitBy) {
+    for word in self.split(by: splitBy) {
       let wordLength = word.characters.count
 
       if currentLineWidth + wordLength + 1 > width {
@@ -199,59 +209,4 @@ internal extension String {
 
     return s
   }
-
-  #else
-
-  func paddedToWidth(width: Int, padBy: Character = " ") -> String {
-    var s = self
-    var currentLength = self.characters.count
-
-    while currentLength < width {
-      s.append(padBy)
-      currentLength += 1
-    }
-
-    return s
-  }
-
-  /**
-   * Wraps a string to the specified width.
-   *
-   * This just does simple greedy word-packing, it doesn't go full Knuth-Plass.
-   * If a single word is longer than the line width, it will be placed (unsplit)
-   * on a line by itself.
-   *
-   * - parameter width:   The maximum length of a line.
-   * - parameter wrapBy:  The line break character to use.
-   * - parameter splitBy: The character to use when splitting the string into words.
-   *
-   * - returns: A new string, wrapped at the given width.
-   */
-  func wrappedAtWidth(width: Int, wrapBy: Character = "\n", splitBy: Character = " ") -> String {
-    var s = ""
-    var currentLineWidth = 0
-
-    for word in self.splitByCharacter(splitBy) {
-      let wordLength = word.characters.count
-
-      if currentLineWidth + wordLength + 1 > width {
-        /* Word length is greater than line length, can't wrap */
-        if wordLength >= width {
-          s += word
-        }
-
-        s.append(wrapBy)
-        currentLineWidth = 0
-      }
-
-      currentLineWidth += wordLength + 1
-      s += word
-      s.append(splitBy)
-    }
-
-    return s
-  }
-
-  #endif
-
 }

--- a/Tests/CommandLine/CommandLineTests.swift
+++ b/Tests/CommandLine/CommandLineTests.swift
@@ -810,7 +810,7 @@ internal class CommandLineTests: XCTestCase {
     XCTAssertGreaterThan(out.characters.count, 0)
 
     /* There should be at least 2 lines per option, plus the intro Usage statement */
-    XCTAssertGreaterThanOrEqual(out.splitByCharacter("\n").count, (opts.count * 2) + 1)
+    XCTAssertGreaterThanOrEqual(out.split(by: "\n").count, (opts.count * 2) + 1)
   }
 
   func testPrintUsageError() {
@@ -825,7 +825,7 @@ internal class CommandLineTests: XCTestCase {
       var out = ""
       cli.printUsage(error, to: &out)
 
-      let errorMessage = out.splitByCharacter("\n", maxSplits: 1)[0]
+      let errorMessage = out.split(by: "\n", maxSplits: 1)[0]
       XCTAssertTrue(errorMessage.hasPrefix("Missing required"))
     }
   }
@@ -891,7 +891,7 @@ internal class CommandLineTests: XCTestCase {
       var out = ""
       cli.printUsage(error, to: &out)
 
-      let o = out.splitByCharacter("\n")
+      let o = out.split(by: "\n")
       XCTAssertTrue(o[0].hasPrefix("[ERROR]"))
       XCTAssertTrue(o[1].hasPrefix("[ABOUT]"))
 

--- a/Tests/CommandLine/StringExtensionTests.swift
+++ b/Tests/CommandLine/StringExtensionTests.swift
@@ -28,9 +28,9 @@ class StringExtensionTests: XCTestCase {
   static var allTests : [(String, (StringExtensionTests) -> () throws -> Void)] {
     return [
       //("testToDouble", testToDouble),
-      ("testSplitByCharacter", testSplitByCharacter),
-      ("testPaddedByCharacter", testPaddedByCharacter),
-      ("testWrappedAtWidth", testWrappedAtWidth),
+      ("testSplit", testSplit),
+      ("testPadded", testPadded),
+      ("testWrapped", testWrapped),
     ]
   }
 
@@ -96,34 +96,34 @@ class StringExtensionTests: XCTestCase {
     setlocale(LC_NUMERIC, "")
   }
 
-  func testSplitByCharacter() {
-    let a = "1,2,3".splitByCharacter(",")
+  func testSplit() {
+    let a = "1,2,3".split(by: ",")
     XCTAssertEqual(a.count, 3, "Failed to split into correct number of components")
 
-    let b = "123".splitByCharacter(",")
+    let b = "123".split(by: ",")
     XCTAssertEqual(b.count, 1, "Failed to split when separator not found")
 
-    let c = "".splitByCharacter(",")
+    let c = "".split(by: ",")
     XCTAssertEqual(c.count, 0, "Splitting empty string should return empty array")
 
-    let e = "a-b-c-d".splitByCharacter("-", maxSplits: 2)
+    let e = "a-b-c-d".split(by: "-", maxSplits: 2)
     XCTAssertEqual(e.count, 3, "Failed to limit splits")
     XCTAssertEqual(e[0], "a", "Invalid value for split 1")
     XCTAssertEqual(e[1], "b", "Invalid value for split 2")
     XCTAssertEqual(e[2], "c-d", "Invalid value for last split")
   }
 
-  func testPaddedByCharacter() {
+  func testPadded() {
     let a = "this is a test"
 
-    XCTAssertEqual(a.paddedToWidth(80).characters.count,
+    XCTAssertEqual(a.padded(toWidth: 80).characters.count,
                    80, "Failed to pad to correct width")
-    XCTAssertEqual(a.paddedToWidth(5).characters.count,
+    XCTAssertEqual(a.padded(toWidth: 5).characters.count,
                    a.characters.count, "Bad padding when pad width is less than string width")
-    XCTAssertEqual(a.paddedToWidth(-2).characters.count,
+    XCTAssertEqual(a.padded(toWidth: -2).characters.count,
                    a.characters.count, "Bad padding with negative pad width")
 
-    let b = a.paddedToWidth(80)
+    let b = a.padded(toWidth: 80)
     #if swift(>=3.0)
       let lastBCharIndex = b.index(before: b.endIndex)
 		#else
@@ -131,7 +131,7 @@ class StringExtensionTests: XCTestCase {
 		#endif
     XCTAssertEqual(b[lastBCharIndex], " " as Character, "Failed to pad with default character")
 
-    let c = a.paddedToWidth(80, padBy: "+")
+    let c = a.padded(toWidth: 80, with: "+")
     #if swift(>=3.0)
       let lastCCharIndex = c.index(before: b.endIndex)
     #else
@@ -140,15 +140,15 @@ class StringExtensionTests: XCTestCase {
     XCTAssertEqual(c[lastCCharIndex], "+" as Character, "Failed to pad with specified character")
   }
 
-  func testWrappedAtWidth() {
+  func testWrapped() {
     let lipsum = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-    for line in lipsum.wrappedAtWidth(80).splitByCharacter("\n") {
+    for line in lipsum.wrapped(atWidth: 80).split(by: "\n") {
       XCTAssertLessThanOrEqual(line.characters.count, 80, "Failed to wrap long line: \(line)")
     }
 
     /* Words longer than the wrap width should not be split */
     let longWords = "Lorem ipsum consectetur adipisicing eiusmod tempor incididunt"
-    let lines = longWords.wrappedAtWidth(3).splitByCharacter("\n")
+    let lines = longWords.wrapped(atWidth: 3).split(by: "\n")
     XCTAssertEqual(lines.count, 8, "Failed to wrap long words")
     for line in lines {
       XCTAssertGreaterThan(line.characters.count, 3, "Bad long word wrapping on line: \(line)")


### PR DESCRIPTION
Some internal cleanups to meet the Swift 3 API guidelines and read a bit more clearly.