### PR TITLE
Fix last broken test on Linux 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
       dist: trusty
       before_install:
         - sudo apt-get install -y clang libicu-dev
+        - sudo locale-gen sv_SE.UTF-8 # for alternate-locale tests
         - ./install-linux-swift.sh
         - export PATH="/swift/usr/bin:${PATH}"
       script:

--- a/Tests/CommandLine/CommandLineTests.swift
+++ b/Tests/CommandLine/CommandLineTests.swift
@@ -25,14 +25,13 @@ import Foundation
 #endif
 
 internal class CommandLineTests: XCTestCase {
-  /* TODO: The commented-out tests segfault on Linux as of the Swift 2.2 2016-01-11 snapshot. */
   static var allTests : [(String, (CommandLineTests) -> () throws -> Void)] {
     return [
       ("testBoolOptions", testBoolOptions),
       ("testIntOptions", testIntOptions),
       ("testCounterOptions", testCounterOptions),
       ("testDoubleOptions", testDoubleOptions),
-      //("testDoubleOptionsInAlternateLocale", testDoubleOptionsInAlternateLocale),
+      ("testDoubleOptionsInAlternateLocale", testDoubleOptionsInAlternateLocale),
       ("testStringOptions", testStringOptions),
       ("testMultiStringOptions", testMultiStringOptions),
       ("testConcatOptionWithValue", testConcatOptionWithValue),

--- a/Tests/CommandLine/StringExtensionTests.swift
+++ b/Tests/CommandLine/StringExtensionTests.swift
@@ -24,10 +24,9 @@ import XCTest
 #endif
 
 class StringExtensionTests: XCTestCase {
-  /* TODO: The commented-out tests segfault on Linux as of the Swift 2.2 2016-01-11 snapshot. */
   static var allTests : [(String, (StringExtensionTests) -> () throws -> Void)] {
     return [
-      //("testToDouble", testToDouble),
+      ("testToDouble", testToDouble),
       ("testSplit", testSplit),
       ("testPadded", testPadded),
       ("testWrapped", testWrapped),


### PR DESCRIPTION
This works fine now, just needed to install the `sv_SE.UTF-8` locale to make sure it's available.