### PR TITLE
Remove conditional imports

### DIFF
--- a/CommandLineKit/CommandLine.swift
+++ b/CommandLineKit/CommandLine.swift
@@ -16,12 +16,6 @@
  */
 
 import Foundation
-/* Required for setlocale(3) */
-#if os(OSX)
-  import Darwin
-#elseif os(Linux)
-  import Glibc
-#endif
 
 let shortOptionPrefix = "-"
 let longOptionPrefix = "--"

--- a/Tests/CommandLineKitTests/CommandLineTests.swift
+++ b/Tests/CommandLineKitTests/CommandLineTests.swift
@@ -15,14 +15,9 @@
  * limitations under the License.
  */
 
-import XCTest
 import Foundation
+import XCTest
 @testable import CommandLineKit
-#if os(OSX)
-  import Darwin
-#elseif os(Linux)
-  import Glibc
-#endif
 
 internal class CommandLineTests: XCTestCase {
   static var allTests : [(String, (CommandLineTests) -> () throws -> Void)] {

--- a/Tests/CommandLineKitTests/StringExtensionTests.swift
+++ b/Tests/CommandLineKitTests/StringExtensionTests.swift
@@ -15,13 +15,9 @@
  * limitations under the License.
  */
 
+import Foundation
 import XCTest
 @testable import CommandLineKit
-#if os(OSX)
-  import Darwin
-#elseif os(Linux)
-  import Glibc
-#endif
 
 class StringExtensionTests: XCTestCase {
   static var allTests : [(String, (StringExtensionTests) -> () throws -> Void)] {


### PR DESCRIPTION
Now that we depend on Foundation, these aren't needed.