### PR TITLE
Unwrap implicit optional

### DIFF
--- a/CommandLineKit/StringExtensions.swift
+++ b/CommandLineKit/StringExtensions.swift
@@ -27,11 +27,11 @@ internal extension String {
    * using localeconv(3).
    */
   private func _localDecimalPoint() -> Character {
-    guard let locale = localeconv() else {
+    guard let locale = localeconv(), let decimalPoint = locale.pointee.decimal_point else {
       return "."
     }
 
-    return Character(UnicodeScalar(UInt8(bitPattern: locale.pointee.decimal_point.pointee)))
+    return Character(UnicodeScalar(UInt8(bitPattern: decimalPoint.pointee)))
   }
 
   /**


### PR DESCRIPTION
Moves the implicitly unwrapped optional `decimal_point` member of the `lconv` struct into in a `guard let` clause. I missed this in #92, thanks to @glessard for spotting it.