### PR TITLE
Add support for Swift 4

### DIFF
--- a/CommandLineKit/CommandLine.swift
+++ b/CommandLineKit/CommandLine.swift
@@ -310,9 +310,15 @@ public class CommandLine {
       }
 
       /* Remove attached argument from flag */
+#if swift(>=3.2)
+      let splitFlag = flagWithArg.split(separator: argumentAttacher, maxSplits: 1)
+      let flag = String(splitFlag[0])
+      let attachedArg: String? = splitFlag.count == 2 ? String(splitFlag[1]) : nil
+#else
       let splitFlag = flagWithArg.split(by: argumentAttacher, maxSplits: 1)
       let flag = splitFlag[0]
       let attachedArg: String? = splitFlag.count == 2 ? splitFlag[1] : nil
+#endif
 
       var flagMatched = false
       for option in _options where option.flagMatch(flag) {

--- a/CommandLineKit/StringExtensions.swift
+++ b/CommandLineKit/StringExtensions.swift
@@ -62,14 +62,22 @@ internal extension String {
     for i in self.characters.indices {
       let c = self[i]
       if c == by && (maxSplits == 0 || numSplits < maxSplits) {
+#if swift(>=3.2)
+        s.append(String(self[curIdx..<i]))
+#else
         s.append(self[curIdx..<i])
+#endif
         curIdx = self.index(after: i)
         numSplits += 1
       }
     }
 
     if curIdx != self.endIndex {
+#if swift(>=3.2)
+      s.append(String(self[curIdx..<self.endIndex]))
+#else
       s.append(self[curIdx..<self.endIndex])
+#endif
     }
 
     return s


### PR DESCRIPTION
This branch allows for compilation in both Swift 3 and Swift 4. It wraps code that didn't compile in Swift 4 in a `#if swift(>=3.2)` conditional. This does *not* change the `Swift Language Version` build setting, so the project will still compile in Swift 3 by default.